### PR TITLE
Allow spaces in directory names (fix only works for zsh)

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -177,7 +177,7 @@ elif compctl &> /dev/null; then
   _z_zsh_tab_completion() {
     local compl
     read -l compl
-    reply=(`z --complete "$compl"`)
+    reply=(${(f)"$(z --complete "$compl")"})
   }
   compctl -U -K _z_zsh_tab_completion z
 fi


### PR DESCRIPTION
When I use the current z.sh in zsh, it offers to complete on parts of paths that contain spaces, e.g. it offers these completions:
/Users/shz/Library/Application  
Support  
Support/TextMate/Themes                                                  

I have replaced the line where the array for zsh's compctl function is created so that it splits only on newline characters, not on whitespace in general.

This problem does not seem to exist in bash.
