### PR TITLE
Edit the Installation section so that it reads better

### DIFF
--- a/README
+++ b/README
@@ -59,7 +59,7 @@ NOTES
         Set $_Z_DATA to change the datafile (default $HOME/.z).
         Set $_Z_NO_RESOLVE_SYMLINKS to prevent symlink resolution.
         Set $_Z_NO_PROMPT_COMMAND if you're handling PROMPT_COMMAND yourself.
-        (These settings should go before the lines added in the "Installation" section.)
+        (These should go before the lines added in the Installation section.)
         Install the provided man page z.1 somewhere like /usr/local/man/man1.
 
        Aging:


### PR DESCRIPTION
Having the "Optionally:" section straight after "Installation:" made it look as if the Installation section had been accidentally deleted. Also the word "Optionally" suggests that you had previously been given something for this to be an option of (e.g. "optionally you can also do this" or "optionally you can do this instead").

Just a suggestion.
