### PR TITLE
Deal with spaces in $HOME

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -49,7 +49,7 @@ _z() {
 
   # maintain the file
   local tempfile
-  tempfile="$(mktemp $datafile.XXXXXX)" || return
+  tempfile="$(mktemp "$datafile.XXXXXX")" || return
   while read line; do
    [ -d "${line%%\|*}" ] && echo $line
   done < "$datafile" | awk -v path="$*" -v now="$(date +%s)" -F"|" '


### PR DESCRIPTION
Hello,

Thanks for writing z.  I have been using it on Linux for a while, and recently tried it out on Windows / Cygwin.  I noticed an oversight that prevented it from working properly when your $HOME path contained spaces.  As always with bash, you can fix all problems by more quoting.

Cheers,
Matthias.
