### PR TITLE
New option: -x

### DIFF
--- a/z.1
+++ b/z.1
@@ -4,7 +4,7 @@ NAME
 z \- jump around
 .SH
 SYNOPSIS
-z [\-chlrt] [regex1 regex2 ... regexn]
+z [\-chlrtx] [regex1 regex2 ... regexn]
 .SH
 AVAILABILITY
 bash, zsh
@@ -31,6 +31,9 @@ match by rank only
 .TP
 \fB\-t\fR
 match by recent access only
+.TP
+\fB\-x\fR
+remove the current directory from the datafile
 .SH EXAMPLES
 .TP 14
 \fBz foo\fR

--- a/z.sh
+++ b/z.sh
@@ -108,7 +108,8 @@ _z() {
    --) while [ "$1" ]; do shift; local fnd="$fnd $1";done;;
    -*) local opt=${1:1}; while [ "$opt" ]; do case ${opt:0:1} in
         c) local fnd="^$PWD $fnd";;
-        h) echo "${_Z_CMD:-z} [-chlrt] args" >&2; return;;
+        h) echo "${_Z_CMD:-z} [-chlrtx] args" >&2; return;;
+        x) sed -i "\:^${PWD}|.*:d" "$datafile";;
         l) local list=1;;
         r) local typ="rank";;
         t) local typ="recent";;


### PR DESCRIPTION
Removes the current directory from the data file.

Use case: sometimes `z tmp` lead me to `/tmp` whereas I was expecting to
be in `~/tmp`, with the new option I can do `z -x tmp`: it removes
`/tmp` from the data file and jumps to `~/tmp`.
