### PR TITLE
Avoid clobbering $? in PROMPT_COMMAND

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -230,7 +230,7 @@ elif complete &> /dev/null; then
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
         # bash populate directory list. avoid clobbering other PROMPT_COMMANDs.
         grep -q "_z --add" <<< "$PROMPT_COMMAND" || {
-            PROMPT_COMMAND="${PROMPT_COMMAND%;}${PROMPT_COMMAND:+;}"'_z --add "$(pwd '$_Z_RESOLVE_SYMLINKS' 2>/dev/null)" 2>/dev/null;'
+            PROMPT_COMMAND="$PROMPT_COMMAND"$'\n''_z --add "$(pwd '$_Z_RESOLVE_SYMLINKS' 2>/dev/null)" 2>/dev/null;'
         }
     }
 fi


### PR DESCRIPTION
Utilizes a trick - backticks work both where a command is expected and
where an argument is expected, so we don't need to worry about whether
or not PROMPT_COMMAND was empty to start with, or whether it ended with
a semicolon.

This is safe to do because the call to _z will never print anything out
(thanks to the &>/dev/null).  It behaves as a no-op in the command
position, and doesn't affect the number of arguments passed to the
command if this comes in the argument position (since it's not quoted
and the expansion is empty).

Fixes #90
