### PR TITLE
redirect to /dev/null instead of '-q' option for solaris 10 or earlier

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -233,7 +233,7 @@ elif complete >/dev/null 2>&1; then
     complete -o filenames -C '_z --complete "$COMP_LINE"' ${_Z_CMD:-z}
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
         # populate directory list. avoid clobbering other PROMPT_COMMANDs.
-        grep -q "_z --add" <<< "$PROMPT_COMMAND" || {
+        grep "_z --add" <<< "$PROMPT_COMMAND" >/dev/null || {
             PROMPT_COMMAND="$PROMPT_COMMAND"$'\n''_z --add "$(pwd '$_Z_RESOLVE_SYMLINKS' 2>/dev/null)" 2>/dev/null;'
         }
     }


### PR DESCRIPTION
The /usr/bin/grep on Solaris 10 or earlier has no '-q' option, http://docs.oracle.com/cd/E26505_01/html/816-5165/grep-1.html
This pull request solve this problem with redirecting to /dev/null instead of '-q' option.
