### PR TITLE
avoid precmd_functions duplicate on zsh

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -218,7 +218,9 @@ if compctl >/dev/null 2>&1; then
                 _z --add "${PWD:A}"
             }
         fi
-        precmd_functions+=(_z_precmd)
+        grep _z_precmd <<< "$precmd_functions" >/dev/null || {
+            precmd_functions+=(_z_precmd)
+        }
     }
     _z_zsh_tab_completion() {
         # tab completion


### PR DESCRIPTION
On zsh, precmd_functions duplicate may occur.

``` console
$ echo $precmd_functions

$ . /path/to/z.sh
$ . /path/to/z.sh
$ echo $precmd_functions
_z_precmd _z_precmd
```

This pull request avoid this.
