### PR TITLE
allow direct cd to non-existent target

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -101,6 +101,7 @@ _z() {
         ' 2>/dev/null
 
     else
+        target=$1
         # list/go
         while [ "$1" ]; do case "$1" in
             --) while [ "$1" ]; do shift; local fnd="$fnd${fnd:+ }$1";done;;
@@ -197,7 +198,11 @@ _z() {
             }
         ')"
         [ $? -gt 0 ] && return
-        [ "$cd" ] && cd "$cd"
+        if [ "$cd" ]; then
+          cd "$cd";
+        else
+          cd "$target";
+        fi
     fi
 }
 


### PR DESCRIPTION
```
mkdir somenewdir
z somenewdir
```

The above case will fail, and this patch fixes that case. A side-effect is that if you try to `z` to a dir which doesn't exist, then you'll get a cd error saying the dir does not exist.

it would be nice if there was a fallback to regular directory tab completion too, but I didn't focus on that.