### PR TITLE
Add manual indexing function

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,10 @@ EXAMPLES
 
        z -l foo      list all dirs matching foo (by frecency)
 
+       zi            add the current directory to the datafile
+                     
+       zi 2          add the current directory + 2 levels down
+
 NOTES
    Installation:
        Put something like this in your $HOME/.bashrc or $HOME/.zshrc:
@@ -58,6 +62,7 @@ NOTES
               Set $_Z_NO_PROMPT_COMMAND to handle PROMPT_COMMAND/precmd  your-
               self.
               Set $_Z_EXCLUDE_DIRS to an array of directories to exclude.
+              set $_ZI_CMD in .bashrc/.zshrc to change the index command (default zi).
               (These  settings  should  go  in  .bashrc/.zshrc before the line
               added above.)
               Install   the   provided   man   page   z.1    somewhere    like

--- a/z.sh
+++ b/z.sh
@@ -13,6 +13,7 @@
 #         set $_Z_NO_RESOLVE_SYMLINKS to prevent symlink resolution.
 #         set $_Z_NO_PROMPT_COMMAND if you're handling PROMPT_COMMAND yourself.
 #         set $_Z_EXCLUDE_DIRS to an array of directories to exclude.
+#         set $_ZI_CMD in .bashrc/.zshrc to change the index command (default zi).
 #
 # USE:
 #     * z foo     # cd to most frecent dir matching foo
@@ -21,21 +22,19 @@
 #     * z -t foo  # cd to most recently accessed dir matching foo
 #     * z -l foo  # list matches instead of cd
 #     * z -c foo  # restrict matches to subdirs of $PWD
+#     * zi [n]    # add the current directory to the datafile, optionally
+#                 # including [n] levels of subdirectories
 
 [ -d "${_Z_DATA:-$HOME/.z}" ] && {
     echo "ERROR: z.sh's datafile (${_Z_DATA:-$HOME/.z}) is a directory."
 }
 
 # indexing function:
-#   * get list of non-hidden directories from current working directory and add them to $datafile
-#   * optionally pass an integer to set number of subdirectories include (default is 1)
-#   * frecency of all locations added will start at |1|(the_current_datetime)
-#   * set $_ZI_CMD in .bashrc/.zshrc to change the command (default zi).
 _zi() {
     local datafile="${_Z_DATA:-$HOME/.z}"
     if [ "$1" ]; then
         for fn in `find $PWD -type d -not \( -name ".?*" -prune \) -maxdepth "$1"`; do
-            echo "$fn|1|$(date +%s)" >> $datafile
+            echo "$fn|1|$(date +%s)" >> $datafile # frecency starts at |1|(the_current_datetime)
         done
     else
         for fn in `find $PWD -type d -not \( -name ".?*" -prune \) -maxdepth 1`; do

--- a/z.sh
+++ b/z.sh
@@ -26,6 +26,27 @@
     echo "ERROR: z.sh's datafile (${_Z_DATA:-$HOME/.z}) is a directory."
 }
 
+# indexing function:
+#   * get list of non-hidden directories from current working directory and add them to $datafile
+#   * optionally pass an integer to set number of subdirectories include (default is 1)
+#   * frecency of all locations added will start at |1|(the_current_datetime)
+#   * set $_ZI_CMD in .bashrc/.zshrc to change the command (default zi).
+_zi() {
+    local datafile="${_Z_DATA:-$HOME/.z}"
+    if [ "$1" ]; then
+        for fn in `find $PWD -type d -not \( -name ".?*" -prune \) -maxdepth "$1"`; do
+            echo "$fn|1|$(date +%s)" >> $datafile
+        done
+    else
+        for fn in `find $PWD -type d -not \( -name ".?*" -prune \) -maxdepth 1`; do
+            echo "$fn|1|$(date +%s)" >> $datafile
+        done
+    fi
+}
+
+alias ${_ZI_CMD:-zi}='_zi 2>&1'
+
+
 _z() {
 
     local datafile="${_Z_DATA:-$HOME/.z}"


### PR DESCRIPTION
Rupa,

I just found z today - it's awesome, thank you.

At first install I was eager to get most of my `~/` indexed, but didn't want to do all that `cd`'ing... So I ran a `find` command on my favorite directories and appended the results + frecency format  to `~/.z`. Thought that may be a cool function to add in.

Command is set to 'zi [#_of_subdirs]', runs from user's current workig directory. Would have preferred 'z -i [#_of_subdirs]' but couldn't get the argument/scope to work out with the existing setup.

If anything about the pull request is bad, please let me know! I'm newly into this open source business, any feedback is greatly appreciated.

Thanks again,
--Sean
