### PR TITLE
Fix -- switch

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -103,7 +103,7 @@ _z() {
     else
         # list/go
         while [ "$1" ]; do case "$1" in
-            --) while [ "$1" ]; do shift; local fnd="$fnd${fnd:+ }$1";done;;
+            --) while [ "$2" ]; do shift; local fnd="$fnd${fnd:+ }$1";done;;
             -*) local opt=${1:1}; while [ "$opt" ]; do case ${opt:0:1} in
                     c) local fnd="^$PWD $fnd";;
                     h) echo "${_Z_CMD:-z} [-chlrtx] args" >&2; return;;


### PR DESCRIPTION
before, this loop would run with no parameters remaining and `shift` would complain. now, it looks ahead one parameter so there's always one to shift.
