### PR TITLE
Prevent extraneous shifting

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -113,7 +113,7 @@ _z() {
                     t) local typ="recent";;
                 esac; opt=${opt:1}; done;;
              *) local fnd="$fnd${fnd:+ }$1";;
-        esac; local last=$1; [ "$2" ] && shift; done
+        esac; local last=$1; [ "$#" -gt 0 ] && shift; done
         [ "$fnd" -a "$fnd" != "^$PWD " ] || local list=1
 
         # if we hit enter on a completion just go there

--- a/z.sh
+++ b/z.sh
@@ -113,7 +113,7 @@ _z() {
                     t) local typ="recent";;
                 esac; opt=${opt:1}; done;;
              *) local fnd="$fnd${fnd:+ }$1";;
-        esac; local last=$1; shift; done
+        esac; local last=$1; [ "$2" ] && shift; done
         [ "$fnd" -a "$fnd" != "^$PWD " ] || local list=1
 
         # if we hit enter on a completion just go there


### PR DESCRIPTION
zsh complains about nothing to shift. this occurs whenever `--` is passed. only shift as necessary.

replaces #129