### PR TITLE
tab completion when .z exists

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -82,7 +82,7 @@ _z() {
         fi
 
     # tab completion
-    elif [ "$1" = "--complete" ]; then
+    elif [ "$1" = "--complete" ] && [ -e $datafile ]; then
         while read line; do
             [ -d "${line%%\|*}" ] && echo $line
         done < "$datafile" | awk -v q="$2" -F"|" '


### PR DESCRIPTION
solve:
If the file `.z` don't exists and I try tab completion I get this error : 

```
rm $HOME/.z
z sr<TAB>
z sr-bash: /home/user/.z: No such file or directory
```
