### PR TITLE
add / to fnd=^$PWD/ in -c: truncated dirs skipped

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -105,7 +105,7 @@ _z() {
         while [ "$1" ]; do case "$1" in
             --) while [ "$1" ]; do shift; local fnd="$fnd${fnd:+ }$1";done;;
             -*) local opt=${1:1}; while [ "$opt" ]; do case ${opt:0:1} in
-                    c) local fnd="^$PWD $fnd";;
+                    c) local fnd="^$PWD/ $fnd";;
                     h) echo "${_Z_CMD:-z} [-chlrtx] args" >&2; return;;
                     x) sed -i -e "\:^${PWD}|.*:d" "$datafile";;
                     l) local list=1;;


### PR DESCRIPTION
It was skipping the first item with `z -c dev` from pwd `/Users/thadk/gitrepos/amp`
126        /Users/thadk/gitrepos/amp/TEMPLATE/x/xx/dev
3076       /Users/thadk/gitrepos/amp211/TEMPLATE/x/xx/dev