### PR TITLE
Fix special char escaping so `mawk` likes it

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -163,7 +163,7 @@ _z() {
                 # use a copy to escape special characters, as we want to return
                 # the original. yeah, this escaping is awful.
                 clean_short = short
-                gsub(/[\(\)\[\]\|]/, "\\\\&", clean_short)
+                gsub(/\[\(\)\[\]\|\]/, "\\\\&", clean_short)
                 for( x in matches ) if( matches[x] && x !~ clean_short ) return
                 return short
             }


### PR DESCRIPTION
One difference in functionality between GNU `awk` and `mawk` is that `mawk`
does not like unescaped brackets as much as `gawk` does. As such, without this fix,
you get a message whenever you run `z <dir>` from `mawk`, complaining about the
unescaped bracket.

From my own testing, this works just fine across both `mawk` and GNU `awk`.