### PR TITLE
Check the running shell using environment variables

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -206,7 +206,7 @@ alias ${_Z_CMD:-z}='_z 2>&1'
 
 [ "$_Z_NO_RESOLVE_SYMLINKS" ] || _Z_RESOLVE_SYMLINKS="-P"
 
-if [ -n "$ZSH_VERSION" ]; then
+if type compctl >/dev/null 2>&1; then
     # zsh
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
         # populate directory list, avoid clobbering any other precmds.
@@ -230,7 +230,7 @@ if [ -n "$ZSH_VERSION" ]; then
         reply=(${(f)"$(_z --complete "$compl")"})
     }
     compctl -U -K _z_zsh_tab_completion _z
-elif [ -n "$BASH_VERSION" ]; then
+elif type complete >/dev/null 2>&1; then
     # bash
     # tab completion
     complete -o filenames -C '_z --complete "$COMP_LINE"' ${_Z_CMD:-z}

--- a/z.sh
+++ b/z.sh
@@ -206,7 +206,7 @@ alias ${_Z_CMD:-z}='_z 2>&1'
 
 [ "$_Z_NO_RESOLVE_SYMLINKS" ] || _Z_RESOLVE_SYMLINKS="-P"
 
-if compctl >/dev/null 2>&1; then
+if [ -n "$ZSH_VERSION" ]; then
     # zsh
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
         # populate directory list, avoid clobbering any other precmds.
@@ -230,7 +230,7 @@ if compctl >/dev/null 2>&1; then
         reply=(${(f)"$(_z --complete "$compl")"})
     }
     compctl -U -K _z_zsh_tab_completion _z
-elif complete >/dev/null 2>&1; then
+elif [ -n "$BASH_VERSION" ]; then
     # bash
     # tab completion
     complete -o filenames -C '_z --complete "$COMP_LINE"' ${_Z_CMD:-z}


### PR DESCRIPTION
I think checking if some shell specific environment variables are set is a nicer method than trying to execute shell builtins, so this commit changes the checks in `z.sh` file to use environment variables ZSH_VERSION and BASH_VERSION instead of executing compctl and complete.

Now I'll explain how trying to run shell builtins can be detrimental to performance:

I was lately observing some slow start while starting new shells. After profiling my .bash.rc, I found the culprit was this line in `z.sh`:
 `if compctl >/dev/null 2>&1; then`

Here is the relevant part from profile:
```
...
0.00066 1.84671  +++ compctl
0.00003 1.84675  +++ '[' -x /usr/lib/command-not-found ']'
1.23529 3.08204  +++ /usr/lib/command-not-found -- compctl
0.00131 3.08336  +++ return 127
...
```

It seems that `z.sh` tries to execute `compctl`, which doesn't exist in `bash`, so bash tries to run it as an executable file, which naturally fails. Then, since there is no such an executable in the system,  `command_not_found_handle` kicks in and calls `command-not-found`, which blocks the shell startup for a significant time.

There are some more other shell specific environment variables but these two seems to fit the bill. If you have any other concerns I'm willing to improve it further.

Regards,
Mert
