### PR TITLE
make matching behavior slightly more intuitive

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -137,49 +137,44 @@ _z() {
                 if( dx < 604800 ) return rank / 2
                 return rank / 4
             }
-            function output(files, out, common) {
+            function output(files, out) {
                 # list or return the desired directory
                 if( list ) {
                     cmd = "sort -n >&2"
                     for( x in files ) {
                         if( files[x] ) printf "%-10s %s\n", files[x], x | cmd
                     }
-                    if( common ) {
-                        printf "%-10s %s\n", "common:", common > "/dev/stderr"
-                    }
                 } else {
-                    if( common ) out = common
                     print out
                 }
             }
-            function common(matches) {
-                # find the common root of a list of matches, if it exists
-                for( x in matches ) {
-                    if( matches[x] && (!short || length(x) < length(short)) ) {
-                        short = x
-                    }
-                }
-                if( short == "/" ) return
-                # use a copy to escape special characters, as we want to return
-                # the original. yeah, this escaping is awful.
-                clean_short = short
-                gsub(/\[\(\)\[\]\|\]/, "\\\\&", clean_short)
-                for( x in matches ) if( matches[x] && x !~ clean_short ) return
-                return short
+            function matchpast(str, ere, thresh) {
+                n = match(str, ere)
+                if (n + RLENGTH > thresh)
+                    return 1
+                return 0
             }
             BEGIN {
                 gsub(" ", ".*", q)
                 hi_rank = ihi_rank = -9999999999
             }
             {
+                n = split($1, broken, "/")
+                threshhold = length($1) - length(broken[n])
+
                 if( typ == "rank" ) {
                     rank = $2
                 } else if( typ == "recent" ) {
                     rank = $3 - t
                 } else rank = frecent($2, $3)
-                if( $1 ~ q ) {
+
+                if (list) # always match if we are listing them
                     matches[$1] = rank
-                } else if( tolower($1) ~ tolower(q) ) imatches[$1] = rank
+                if (matchpast($1, q, threshhold))
+                    matches[$1] = rank
+                else if (matchpast(tolower($1), tolower(q), threshhold))
+                    imatches[$1] = rank
+
                 if( matches[$1] && matches[$1] > hi_rank ) {
                     best_match = $1
                     hi_rank = matches[$1]
@@ -191,9 +186,9 @@ _z() {
             END {
                 # prefer case sensitive
                 if( best_match ) {
-                    output(matches, best_match, common(matches))
+                    output(matches, best_match)
                 } else if( ibest_match ) {
-                    output(imatches, ibest_match, common(imatches))
+                    output(imatches, ibest_match)
                 }
             }
         ')"


### PR DESCRIPTION
normal z matching behavior, especially wrt the `common()` function is a little odd:

```bash
mkdir -p aaa/bbb
cd aaa
cd -
cd aaa/bbb
cd -
z aaa # goes to aaa, even though aaa/bbb has higher frecency
cd -
mkdir -p zzz/aaa
cd zzz/aaa
cd -
cd aaa/bbb
cd -
cd aaa/bbb # increasing the frecency of the subdir
cd -
z aaa # goes to ./aaa/bbb (deeper in the directory tree than I am trying to jump)
```
In fact, if an unrelated path matching `/aaa/` is in z's database, and `aaa/bbb` is of higher frecency than `aaa`, there is no way to jump to `aaa` without also jumping deeper into `aaa/bbb`.

This patch changes the matching behavior so z will only jump to a deeper directory if it is explicitly matched - e.g., `z aaa` will never jump below the directory matching `aaa`, which I find to be slightly more intuitive.