### PR TITLE
Add option to print target dir without cd'ing

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -109,6 +109,7 @@ _z() {
                     h) echo "${_Z_CMD:-z} [-chlrtx] args" >&2; return;;
                     x) sed -i -e "\:^${PWD}|.*:d" "$datafile";;
                     l) local list=1;;
+                    p) local printonly=1;;
                     r) local typ="rank";;
                     t) local typ="recent";;
                 esac; opt=${opt:1}; done;;
@@ -198,7 +199,11 @@ _z() {
             }
         ')"
         [ $? -gt 0 ] && return
-        [ "$cd" ] && cd "$cd"
+        if [ -n "$printonly" ] ; then
+          echo "$cd"
+        else
+          [ "$cd" ] && cd "$cd"
+        fi
     fi
 }
 


### PR DESCRIPTION
Not sure if this will be of interest to many people, or if there's a more elegant way to do this, but I've been enjoying z's directory expansion enough that I wanted to try using it for things other than the cd command.
With this patch and `alias zz='z -p'`, one can `` open `zz cool-files` ``, etc.