### PR TITLE
Use database locking (flock) for zsh

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -60,7 +60,7 @@ _z() {
         done
 
         # maintain the data file
-        local tempfile="$datafile.$RANDOM"
+        local tempfile="$(mktemp "${datafile}.XXXXXXXX")"
         _z_dirs | awk -v path="$*" -v now="$(date +%s)" -F"|" '
             BEGIN {
                 rank[path] = 1

--- a/z.sh
+++ b/z.sh
@@ -61,6 +61,13 @@ _z() {
 
         # maintain the data file
         local tempfile="$(mktemp "${datafile}.XXXXXXXX")"
+        if [ "$_Z_USE_ZSYSTEM_FLOCK" -eq 1 ]; then
+            # make sure datafile exists (for locking)
+            [ -f "$datafile" ] || touch "$datafile"
+            local lockfd
+            # grab exclusive lock (released when function exits)
+            zsystem flock -f lockfd "$datafile" || return
+        fi
         _z_dirs | awk -v path="$*" -v now="$(date +%s)" -F"|" '
             BEGIN {
                 rank[path] = 1
@@ -84,12 +91,20 @@ _z() {
                 } else for( x in rank ) print x "|" rank[x] "|" time[x]
             }
         ' 2>/dev/null >| "$tempfile"
-        # do our best to avoid clobbering the datafile in a race condition.
-        if [ $? -ne 0 -a -f "$datafile" ]; then
+        local ret=$?
+        if [ "$_Z_USE_ZSYSTEM_FLOCK" -eq 1 ]; then
+            # replace contents of datafile with tempfile
+            env cat "$tempfile" >| "$datafile"
+            [ "$_Z_OWNER" ] && chown $_Z_OWNER:$(id -ng $_Z_OWNER) "$datafile"
             env rm -f "$tempfile"
         else
-            [ "$_Z_OWNER" ] && chown $_Z_OWNER:$(id -ng $_Z_OWNER) "$tempfile"
-            env mv -f "$tempfile" "$datafile" || env rm -f "$tempfile"
+            # do our best to avoid clobbering the datafile in a race condition.
+            if [ $ret -ne 0 -a -f "$datafile" ]; then
+                env rm -f "$tempfile"
+            else
+                [ "$_Z_OWNER" ] && chown $_Z_OWNER:$(id -ng $_Z_OWNER) "$tempfile"
+                env mv -f "$tempfile" "$datafile" || env rm -f "$tempfile"
+            fi
         fi
 
     # tab completion
@@ -213,6 +228,14 @@ _z() {
 alias ${_Z_CMD:-z}='_z 2>&1'
 
 [ "$_Z_NO_RESOLVE_SYMLINKS" ] || _Z_RESOLVE_SYMLINKS="-P"
+
+if type zmodload >/dev/null 2>&1; then
+    # load zsh/system for the zsystem flock builtin
+    zmodload zsh/system &>/dev/null
+    if zsystem supports flock &>/dev/null; then
+        _Z_USE_ZSYSTEM_FLOCK=1
+    fi
+fi
 
 if type compctl >/dev/null 2>&1; then
     # zsh


### PR DESCRIPTION
This PR adds support for locking the database (via advisory file locking) during update when `zsh` is used as shell. This is done via `zsystem flock` that is available in the `zsh/system` module. The lock is acquired before the database is read and kept until the (new) database has been written and the command has exited.

A separate code path is needed when updating the database entry because replacing the file (via mv) would cause any process waiting for a lock to fail. Here we simply clobber the database with the contents of the tempfile.

This is a partial fix for #198, more specifically, this only fixes the problem on `zsh`.

// ping @balta2ar