### PR TITLE
Fixed the _z_precmd:1: nice(5) failed: operation not permitted error

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -218,11 +218,11 @@ if type compctl >/dev/null 2>&1; then
         # populate directory list, avoid clobbering any other precmds.
         if [ "$_Z_NO_RESOLVE_SYMLINKS" ]; then
             _z_precmd() {
-                (_z --add "${PWD:a}" &)
+                (_z --add "${PWD:a}" &) >/dev/null 2>&1
             }
         else
             _z_precmd() {
-                (_z --add "${PWD:A}" &)
+                (_z --add "${PWD:A}" &) >/dev/null 2>&1
             }
         fi
         [[ -n "${precmd_functions[(r)_z_precmd]}" ]] || {


### PR DESCRIPTION
I've found that when I use Antigen or zgen I usually get this error when I install z:

_z_precmd:1: nice(5) failed: operation not permitted

I've fixed this error but directing that output to null. It's tested and working on Windows 10 Bash so I assume it'll work on native Linux terminal as well.

If this doesn't get accepted, people that need to fix this error can clone the fork that is located at:

[https://github.com/Kerren/z](https://github.com/Kerren/z)