### PR TITLE
add support for argument to x, to enable removing (not-current) directory

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -22,6 +22,7 @@
 #     * z -t foo  # cd to most recently accessed dir matching foo
 #     * z -l foo  # list matches instead of cd
 #     * z -c foo  # restrict matches to subdirs of $PWD
+#     * z -x foo  # removes dir `foo` from z database
 
 [ -d "${_Z_DATA:-$HOME/.z}" ] && {
     echo "ERROR: z.sh's datafile (${_Z_DATA:-$HOME/.z}) is a directory."
@@ -116,7 +117,9 @@ _z() {
                     l) local list=1;;
                     r) local typ="rank";;
                     t) local typ="recent";;
-                    x) sed -i -e "\:^${PWD}|.*:d" "$datafile";;
+                    x) local xdir="${PWD}"
+                       if [ $# -gt 1 ]; then xdir="$2"; shift; fi
+                       sed -i -e "\:^${xdir}|.*:d" "$datafile";;
                 esac; opt=${opt:1}; done;;
              *) local fnd="$fnd${fnd:+ }$1";;
         esac; local last=$1; [ "$#" -gt 0 ] && shift; done


### PR DESCRIPTION
Workaround for #159

Does not work (`PROMPT_COMMAND` always adds `$PWD` again):
`[user@there]$ z -x`

Does work:
`[user@here]$ z -x there`