### PR TITLE
Return zero when listing with `-l`

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -205,9 +205,11 @@ _z() {
             }
         ')"
 
-        [ $? -eq 0 ] && [ "$cd" ] && {
-          if [ "$echo" ]; then echo "$cd"; else builtin cd "$cd"; fi
-        }
+        [ "$?" -eq 0 ] && if [ "$cd" ]; then
+            if [ "$echo" ]; then echo "$cd"; else builtin cd "$cd"; fi
+        else
+            [ -n "$list" ]
+        fi
     fi
 }
 


### PR DESCRIPTION
Current logic returns a non-zero code, because `"$cd"` is empty when using `-l`.