### PR TITLE
Use chpwd instead of precmd hook, and add-zsh-hook

### DIFF
--- a/README
+++ b/README
@@ -60,7 +60,7 @@ NOTES
               Set $_Z_CMD to change the command name (default z).
               Set $_Z_DATA to change the datafile (default $HOME/.z).
               Set $_Z_NO_RESOLVE_SYMLINKS to prevent symlink resolution.
-              Set $_Z_NO_PROMPT_COMMAND to handle PROMPT_COMMAND/precmd  your-
+              Set $_Z_NO_PROMPT_COMMAND to handle  PROMPT_COMMAND/chpwd  your-
               self.
               Set $_Z_EXCLUDE_DIRS to an array of directory trees to  exclude.
               Set $_Z_OWNER to allow usage when in 'sudo -s' mode.
@@ -116,11 +116,11 @@ ENVIRONMENT
        resolved when added to the datafile.
 
        In bash, z appends a command to the PROMPT_COMMAND environment variable
-       to maintain its database. In zsh, z appends a function _z_precmd to the
-       precmd_functions array.
+       to maintain its database.  In zsh, z sets function _z_chpwd as a  chpwd
+       hook.
 
        The environment variable $_Z_NO_PROMPT_COMMAND can be set if  you  want
-       to handle PROMPT_COMMAND or precmd yourself.
+       to handle PROMPT_COMMAND or chpwd yourself.
 
        The  environment  variable  $_Z_EXCLUDE_DIRS  can be set to an array of
        directory trees to exclude from tracking.  $HOME  is  always  excluded.

--- a/z.1
+++ b/z.1
@@ -81,7 +81,7 @@ Set \fB$_Z_DATA\fR to change the datafile (default \fB$HOME/.z\fR).
 Set \fB$_Z_NO_RESOLVE_SYMLINKS\fR to prevent symlink resolution.
 .RE
 .RS
-Set \fB$_Z_NO_PROMPT_COMMAND\fR to handle \fBPROMPT_COMMAND/precmd\fR yourself.
+Set \fB$_Z_NO_PROMPT_COMMAND\fR to handle \fBPROMPT_COMMAND/chpwd\fR yourself.
 .RE
 .RS
 Set \fB$_Z_EXCLUDE_DIRS\fR to an array of directory trees to exclude.
@@ -144,11 +144,11 @@ resolving of symlinks. If it is not set, symbolic links will be resolved when
 added to the datafile.
 .P
 In bash, \fBz\fR appends a command to the \fBPROMPT_COMMAND\fR environment
-variable to maintain its database. In zsh, \fBz\fR appends a function
-\fB_z_precmd\fR to the \fBprecmd_functions\fR array.
+variable to maintain its database. In zsh, \fBz\fR sets function \fB_z_chpwd\fR
+as a \fBchpwd\fR hook.
 .P
 The environment variable \fB$_Z_NO_PROMPT_COMMAND\fR can be set if you want to
-handle \fBPROMPT_COMMAND\fR or \fBprecmd\fR yourself.
+handle \fBPROMPT_COMMAND\fR or \fBchpwd\fR yourself.
 .P
 The environment variable \fB$_Z_EXCLUDE_DIRS\fR can be set to an array of
 directory trees to exclude from tracking. \fB$HOME\fR is always excluded.

--- a/z.sh
+++ b/z.sh
@@ -218,19 +218,18 @@ alias ${_Z_CMD:-z}='_z 2>&1'
 if type compctl >/dev/null 2>&1; then
     # zsh
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
-        # populate directory list, avoid clobbering any other precmds.
+        # populate directory list, avoid clobbering any other chpwd_functions.
         if [ "$_Z_NO_RESOLVE_SYMLINKS" ]; then
-            _z_precmd() {
+            _z_chpwd() {
                 (_z --add "${PWD:a}" &)
             }
         else
-            _z_precmd() {
+            _z_chpwd() {
                 (_z --add "${PWD:A}" &)
             }
         fi
-        [[ -n "${precmd_functions[(r)_z_precmd]}" ]] || {
-            precmd_functions[$(($#precmd_functions+1))]=_z_precmd
-        }
+        autoload -Uz add-zsh-hook
+        add-zsh-hook -Uz chpwd _z_chpwd
     }
     _z_zsh_tab_completion() {
         # tab completion


### PR DESCRIPTION
This triggers z at every working directory change, instead of at every prompt, in zsh. Use add-zsh-hook to set up the _z_chpwd function.

Also, update the async job call inside _z_chpwd. The parenthesis, which do the call in a subshell, are not necessary, and `&!` makes sure the job is immediately disowned (and there's no output of the process ID or it's termination status). See http://zsh.sourceforge.net/Doc/Release/Jobs-_0026-Signals.html

This code is compatible with zsh versions >= 5.0.

Also update man page and README.

Closes #210