### PR TITLE
Solaris 11 compatibility (uses nawk)

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -37,6 +37,13 @@ _z() {
     # bail if we don't own ~/.z and $_Z_OWNER not set
     [ -z "$_Z_OWNER" -a -f "$datafile" -a ! -O "$datafile" ] && return
 
+    awk() {
+      case $(uname -a) in
+        SunOS*) nawk "$@" ;;
+        *) command awk "$@" ;;
+      esac
+    }
+
     _z_dirs () {
         while read line; do
             # only count directories


### PR DESCRIPTION
`z` requires a version of `awk` that has the `-v` option. Solaris 11 uses by default an antiquated version of `awk` that does not have that option. Its `nawk` does have `-v`, however. I propose adding the function

```
awk() {
    case $(uname -a) in
       SunOS*) nawk "$@" ;;
       *) command awk "$@" ;;
    esac
}
```

It simply redirects calls on awk to nawk on Solaris and should have no effect on other systems. I have tested it with both `bash` and `zsh`.