### PR TITLE
Avoid race condition when listing matches

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -147,12 +147,12 @@ _z() {
             function output(files, out, common) {
                 # list or return the desired directory
                 if( list ) {
+                    if( common ) {
+                        printf "%-10s %s\n", "common:", common > "/dev/stderr"
+                    }
                     cmd = "sort -n >&2"
                     for( x in files ) {
                         if( files[x] ) printf "%-10s %s\n", files[x], x | cmd
-                    }
-                    if( common ) {
-                        printf "%-10s %s\n", "common:", common > "/dev/stderr"
                     }
                 } else {
                     if( common ) out = common


### PR DESCRIPTION
When listing matches common root is *always* printed first. I guess that's because pipe operator spawns new process and there's race condition.

This change makes code flow consistent with output.