### PR TITLE
Support for group names containing spaces

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -89,7 +89,7 @@ _z() {
         if [ $? -ne 0 -a -f "$datafile" ]; then
             env rm -f "$tempfile"
         else
-            [ "$_Z_OWNER" ] && chown $_Z_OWNER:$(id -ng $_Z_OWNER) "$tempfile"
+            [ "$_Z_OWNER" ] && chown $_Z_OWNER:"$(id -ng $_Z_OWNER)" "$tempfile"
             env mv -f "$tempfile" "$datafile" || env rm -f "$tempfile"
         fi
 


### PR DESCRIPTION
When Active Directory is used for Mac authentication then the group name could be "MyCompany\Domain Users".  This causes an error in z during the chown such as "chown: MyCompany\Domain: illegal group name"