### PR TITLE
Fix zsh stalled $RANDOM variable

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -223,10 +223,12 @@ if type compctl >/dev/null 2>&1; then
         if [ "$_Z_NO_RESOLVE_SYMLINKS" ]; then
             _z_precmd() {
                 (_z --add "${PWD:a}" &)
+                : $RANDOM
             }
         else
             _z_precmd() {
                 (_z --add "${PWD:A}" &)
+                : $RANDOM
             }
         fi
         [[ -n "${precmd_functions[(r)_z_precmd]}" ]] || {


### PR DESCRIPTION
This change references `$RANDOM` outside the subshell to refresh it for the next subshell invocation. Otherwise, subsequent runs of the function get the same value and, if run simultaneously, they may clobber each others' temp .z files.

This is due to how zsh distributes RANDOM values when running inside a subshell: 

    subshells that reference RANDOM will result in identical pseudo-random
    values unless the value of RANDOM is referenced or seeded in the parent
    shell in between subshell invocations

See: http://zsh.sourceforge.net/Doc/Release/Parameters.html#index-RANDOM

Fixes #198 
Related: https://github.com/rupa/z/issues/198#issuecomment-417098496