### PR TITLE
Fix -r and -t options with common dirs (fixes #235)

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -158,7 +158,7 @@ _z() {
                         printf "%-10s %s\n", "common:", common > "/dev/stderr"
                     }
                 } else {
-                    if( common ) best_match = common
+                    if( common && !typ ) best_match = common
                     print best_match
                 }
             }


### PR DESCRIPTION
Avoid using the common root when `rank` or `recent` are used so that subdirs with higher rank get properly selected.