### PR TITLE
add (un)install functionality to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ $(eval MAN_PATH=$(shell command -v manpath >/dev/null 2>&1 && manpath | \
 
 # first we copy the man file to a directory in the manpath
 # then we copy the z.sh file to the home directory
-# then we add '. ~/z.sh' to the .bashrc file to source z.sh.
+# then we add '. ~/z.sh' to the .bashrc file to source z.sh
+# we then reload the bashrc file
 install:
 	@cp z.1 $(MAN_PATH)/man1/z.1
 	@cp z.sh $(HOME)/z.sh
 	@[ -f $(HOME)/.bashrc ] && echo ". ${HOME}/z.sh" >> $(HOME)/.bashrc
+	@. $(HOME)/.bashrc
 	@echo "Installation completed! cd around for a while to build up the db. \
 		PROFIT!!"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,26 @@
+# check if the command manpath exists. Use the first path found as the path
+# to copy z.1 to.
+$(eval MAN_PATH=$(shell command -v manpath >/dev/null 2>&1 && manpath | \
+	cut -d ':' -f1))
+
+# first we copy the man file to a directory in the manpath
+# then we copy the z.sh file to the home directory
+# then we add '. ~/z.sh' to the .bashrc file to source z.sh.
+install:
+	@cp z.1 $(MAN_PATH)/man1/z.1
+	@cp z.sh $(HOME)/z.sh
+	@[ -f $(HOME)/.bashrc ] && echo ". ${HOME}/z.sh" >> $(HOME)/.bashrc
+	@echo "Installation completed! cd around for a while to build up the db. \
+		PROFIT!!"
+
+# we only need to remove 2 files. We can't remove lines from the .basrc file
+# of people because this could do some really bad stuff
+uninstall:
+	@rm $(MAN_PATH)/man1/z.1
+	@rm $(HOME)/z.sh
+	@echo "Don't forgot to remove the '. ~/z.sh' line in your .bashrc file"
+
 readme:
 	@groff -man -Tascii z.1 | col -bx
 
-.PHONY: readme
+.PHONY: readme install uninstall MAN_PATH

--- a/README
+++ b/README
@@ -1,6 +1,10 @@
 This fork of rupa/z aims to better maintain the project. Please file bug reports etc
 here! That way we can make this tool even better then it already is.
 
+CHANGELOG / TODO
+- [x] Makefile for installing the files
+- [ ] Use the XDG standard ($XDG_CONFIG_HOME)
+
 Z(1)                             User Commands                            Z(1)
 
 

--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+This fork of rupa/z aims to better maintain the project. Please file bug reports etc
+here! That way we can make this tool even better then it already is.
+
 Z(1)                             User Commands                            Z(1)
 
 


### PR DESCRIPTION
This PR adds the enhancement proposed in #251. The user is now able to clone or download the repo and use `$ make install` to install everything to get `z` up and running. It is also possible to uninstall using `$ make uninstall`. The `readme` option is still available.