### PR TITLE
fix argument handling

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -111,9 +111,9 @@ _z() {
     else
         # list/go
         local echo fnd last list opt typ
-        while [ "$1" ]; do case "$1" in
-            --) while [ "$1" ]; do shift; fnd="$fnd${fnd:+ }$1";done;;
-            -*) opt=${1:1}; while [ "$opt" ]; do case ${opt:0:1} in
+        while ! [ -z "$1" ]; do case "$1" in
+            --) while ! [ -z "$1" ]; do shift; fnd="$fnd${fnd:+ }$1";done;;
+            -*) opt=${1:1}; while ! [ -z "$opt" ]; do case ${opt:0:1} in
                     c) fnd="^$PWD $fnd";;
                     e) echo=1;;
                     h) echo "${_Z_CMD:-z} [-cehlrtx] args" >&2; return;;
@@ -206,7 +206,7 @@ _z() {
             }
         ')"
 
-        [ $? -eq 0 ] && [ "$cd" ] && {
+        [ $? -eq 0 ] && ! [ -z "$cd" ] && {
           if [ "$echo" ]; then echo "$cd"; else builtin cd "$cd"; fi
         }
     fi


### PR DESCRIPTION
If the argument is -t, [ -t ] will test if stdout is a TTY. We should
use -z to test if a string is empty instead.