### PR TITLE
Fix no such file or directory error

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -39,6 +39,8 @@ _z() {
     [ -z "$_Z_OWNER" -a -f "$datafile" -a ! -O "$datafile" ] && return
 
     _z_dirs () {
+        [ -f "$datafile" ] || return
+
         local line
         while read line; do
             # only count directories


### PR DESCRIPTION
Fixes https://github.com/rupa/z/issues/92

What's happening here is on first invocation of `cd`, the `datafile` (which is `$_Z_DATA` or `$HOME/.z` by default) has not yet been created before the function `_z_dirs` is called. Since `_z_dirs` attempts to read from `$datafile`, this causes the error mentioned in the issue.

Since we haven't visited any directories yet if `$datafile` doesn't exist, we can safely return from the function without echoing anything.