### PR TITLE
Fix removing the current directory

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -120,7 +120,7 @@ _z() {
                     l) list=1;;
                     r) typ="rank";;
                     t) typ="recent";;
-                    x) sed -i -e "\:^${PWD}|.*:d" "$datafile";;
+                    x) sed -i.old -e "\:^${PWD}|.*:d" "$datafile";;
                 esac; opt=${opt:1}; done;;
              *) fnd="$fnd${fnd:+ }$1";;
         esac; last=$1; [ "$#" -gt 0 ] && shift; done


### PR DESCRIPTION
After running "z -x" command, the datafile contains only one line, the current directory. 
Sigh. At least, on Windows with sed (GNU sed 4.5) contained in git bash git version 2.20.1.windows.1.

Adding the suffix ".old" to the option "-i" it seems the issue is fixed: the current directory is reset.
Indeed it is removed, but don't forget Z cmd is added to the PROMPT_COMMAND.
So when the command is terminated, the current directory is added again with visit counter equals to 1.