### PR TITLE
Corrected sort order in tab completion

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -148,7 +148,7 @@ _z() {
             function output(matches, best_match, common) {
                 # list or return the desired directory
                 if( list ) {
-                    cmd = "sort -n >&2"
+                    cmd = "sort -g >&2"
                     for( x in matches ) {
                         if( matches[x] ) {
                             printf "%-10s %s\n", matches[x], x | cmd


### PR DESCRIPTION
The tab completion for z lists hits in wrong order, not by rank. Switching from "-n" to "-g" for sort (i.e. general numeric) is required for the float rank value.