### PR TITLE
Support XDG-specification

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -33,7 +33,7 @@ _z() {
     local DIRECTORY_NAME="z"
 
     # fallback to default XDG directory
-    local DEFAULT_DATA_DIR="$HOME/.local/share/$DIRECTORY_NAME"
+    local DEFAULT_DATA_DIR="$HOME/.local/state/$DIRECTORY_NAME"
     local datafile=$DEFAULT_DATA_DIR/$DATA_FILE_NAME
 
     # Backwards compatible _Z_DATA definition

--- a/z.sh
+++ b/z.sh
@@ -29,8 +29,20 @@
 }
 
 _z() {
+    local DATA_FILE_NAME="z"
+    local DIRECTORY_NAME="z"
 
-    local datafile="${_Z_DATA:-$HOME/.z}"
+    # fallback to default XDG directory
+    local DEFAULT_DATA_DIR="$HOME/.local/share/$DIRECTORY_NAME"
+    local datafile=$DEFAULT_DATA_DIR/$DATA_FILE_NAME
+
+    # Backwards compatible _Z_DATA definition
+    if [[ -n $_Z_DATA ]]; then
+        datafile=$_Z_DATA
+    # respect user specific XDG settings
+    elif [[ -n $XDG_DATA_HOME ]]; then
+        datafile=$XDG_DATA_HOME/$DIRECTORY_NAME/$DATA_FILE_NAME
+    fi
 
     # if symlink, dereference
     [ -h "$datafile" ] && datafile=$(readlink "$datafile")


### PR DESCRIPTION
see: https://specifications.freedesktop.org/basedir-spec/basedir-spec-0.6.html

This is backwards compatible with the old `_Z_DATA` env-var but enhances
the user experiences with the XDG-specification.

closes #267