### PR TITLE
unset POSIXLY_CORRECT for bash

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -33,6 +33,8 @@ _z() {
 
     local datafile="${_Z_DATA:-$HOME/.z}"
 
+    unset POSIXLY_CORRECT
+    
     # if symlink, dereference
     [ -h "$datafile" ] && datafile=$(readlink "$datafile")
 


### PR DESCRIPTION
If POSIXLY_CORRECT is set in the bash process environment running `z somePath` produces:
```
sh: command substitution: line 168: syntax error near unexpected token `<'
sh: command substitution: line 168: ` < <( _z_dirs ) awk -v t="$(date +%s)" -v list="$list" -v typ="$typ" -v q="$fnd" -F"|" ''
```