### PR TITLE
Update z.sh

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -60,7 +60,7 @@ _z() {
         # don't track excluded directory trees
         local exclude
         for exclude in "${_Z_EXCLUDE_DIRS[@]}"; do
-            case "$*" in "$exclude*") return;; esac
+            case "$*" in "$exclude"*) return;; esac
         done
 
         # maintain the data file


### PR DESCRIPTION
Double-quote in wrong position meant that Excluding directories feature didn't work.