### PR TITLE
Add support for using pushd instead of cd

### DIFF
--- a/README
+++ b/README
@@ -3,10 +3,10 @@ Z(1)                             User Commands                            Z(1)
 
 
 NAME
-       z - jump around
+       z|zz - jump around
 
 SYNOPSIS
-       z [-chlrtx] [regex1 regex2 ... regexn]
+       {z|zz} [-chlprtx] [regex1 regex2 ... regexn]
 
 AVAILABILITY
        bash, zsh
@@ -20,6 +20,9 @@ DESCRIPTION
 
        For example, z foo bar would match /foo/bar but not /bar/foo.
 
+       zz  command  is  an alias to z -p. It behaves exactly like z, only uses
+       pushd instead of cd.
+
 OPTIONS
        -c     restrict matches to subdirectories of the current directory
 
@@ -28,6 +31,9 @@ OPTIONS
        -h     show a brief help message
 
        -l     list only
+
+       -p     Use pushd instead of cd. zz command has this option set  by  de-
+              fault
 
        -r     match by rank only
 
@@ -46,6 +52,8 @@ EXAMPLES
 
        z -l foo      list all dirs matching foo (by frecency)
 
+       zz foo        pushd to most frecent dir matching foo
+
 NOTES
    Installation:
        Put something like this in your $HOME/.bashrc or $HOME/.zshrc:
@@ -57,7 +65,8 @@ NOTES
        PROFIT!!
 
        Optionally:
-              Set $_Z_CMD to change the command name (default z).
+              Set $_Z_CMD to change the "cd" command name (default z).
+              Set $_ZZ_CMD to change the "pushd" command name (default zz).
               Set $_Z_DATA to change the datafile (default $HOME/.z).
               Set  $_Z_MAX_SCORE  lower  to  age  entries  out faster (default
               9000).
@@ -109,6 +118,9 @@ ENVIRONMENT
 
        The contents of the variable $_Z_CMD is aliased to _z 2>&1. If not set,
        $_Z_CMD defaults to z.
+
+       In similar fashion, the contents of the variable $_ZZ_CMD is aliased to
+       _z -p 2>&1. If not set, $_ZZ_CMD defaults to zz.
 
        The  environment  variable $_Z_DATA can be used to control the datafile
        location. If it is not defined, the location defaults to $HOME/.z.

--- a/z.1
+++ b/z.1
@@ -1,10 +1,10 @@
 .TH "Z" "1" "January 2013" "z" "User Commands"
 .SH
 NAME
-z \- jump around
+z|zz \- jump around
 .SH
 SYNOPSIS
-z [\-chlrtx] [regex1 regex2 ... regexn]
+{z|zz} [\-chlprtx] [regex1 regex2 ... regexn]
 .SH
 AVAILABILITY
 bash, zsh
@@ -16,6 +16,8 @@ After a short learning phase, \fBz\fR will take you to the most 'frecent'
 directory that matches ALL of the regexes given on the command line, in order.
 
 For example, \fBz foo bar\fR would match \fB/foo/bar\fR but not \fB/bar/foo\fR.
+
+\fBzz\fR command is an alias to \fBz -p\fR. It behaves exactly like z, only uses pushd instead of cd.
 .SH
 OPTIONS
 .TP
@@ -30,6 +32,9 @@ show a brief help message
 .TP
 \fB\-l\fR
 list only
+.TP
+\fB\-p\fR
+Use \fBpushd\fR instead of \fBcd\fR. zz command has this option set by default
 .TP
 \fB\-r\fR
 match by rank only
@@ -55,6 +60,9 @@ cd to most recently accessed dir matching foo
 .TP 14
 \fBz -l foo\fR
 list all dirs matching foo (by frecency)
+.TP 14
+\fBzz foo\fR
+pushd to most frecent dir matching foo
 .SH
 NOTES
 .SS
@@ -72,7 +80,10 @@ PROFIT!!
 .P
 Optionally:
 .RS
-Set \fB$_Z_CMD\fR to change the command name (default \fBz\fR).
+Set \fB$_Z_CMD\fR to change the "cd" command name (default \fBz\fR).
+.RE
+.RS
+Set \fB$_ZZ_CMD\fR to change the "pushd" command name (default \fBzz\fR).
 .RE
 .RS
 Set \fB$_Z_DATA\fR to change the datafile (default \fB$HOME/.z\fR).
@@ -138,6 +149,9 @@ A function \fB_z()\fR is defined.
 .P
 The contents of the variable \fB$_Z_CMD\fR is aliased to \fB_z 2>&1\fR. If not
 set, \fB$_Z_CMD\fR defaults to \fBz\fR.
+.P
+In similar fashion, the contents of the variable \fB$_ZZ_CMD\fR is aliased to
+\fB_z -p 2>&1\fR. If not set, \fB$_ZZ_CMD\fR defaults to \fBzz\fR.
 .P
 The environment variable \fB$_Z_DATA\fR can be used to control the datafile
 location. If it is not defined, the location defaults to \fB$HOME/.z\fR.

--- a/z.sh
+++ b/z.sh
@@ -26,6 +26,7 @@
 #     * z -c foo  # restrict matches to subdirs of $PWD
 #     * z -x      # remove the current directory from the datafile
 #     * z -h      # show a brief help message
+#     * zz [all of the above] # same as with "z", but use pushd instead of cd
 
 [ -d "${_Z_DATA:-$HOME/.z}" ] && {
     echo "ERROR: z.sh's datafile (${_Z_DATA:-$HOME/.z}) is a directory."
@@ -118,14 +119,16 @@ _z() {
 
     else
         # list/go
-        local echo fnd last list opt typ
+        local echo fnd last list opt typ cd_cmd
+        cd_cmd="cd"
         while [ "$1" ]; do case "$1" in
             --) while [ "$1" ]; do shift; fnd="$fnd${fnd:+ }$1";done;;
             -*) opt=${1:1}; while [ "$opt" ]; do case ${opt:0:1} in
                     c) fnd="^$PWD $fnd";;
                     e) echo=1;;
-                    h) echo "${_Z_CMD:-z} [-cehlrtx] args" >&2; return;;
+                    h) echo "{${_Z_CMD:-z}|${_ZZ_CMD:-zz}} [-cehlprtx] args" >&2; return;;
                     l) list=1;;
+                    p) cd_cmd="pushd";;
                     r) typ="rank";;
                     t) typ="recent";;
                     x) sed -i -e "\:^${PWD}|.*:d" "$datafile";;
@@ -137,7 +140,7 @@ _z() {
         # if we hit enter on a completion just go there
         case "$last" in
             # completions will always start with /
-            /*) [ -z "$list" -a -d "$last" ] && builtin cd "$last" && return;;
+            /*) [ -z "$list" -a -d "$last" ] && builtin $cd_cmd "$last" && return;;
         esac
 
         # no file yet
@@ -216,7 +219,7 @@ _z() {
 
         if [ "$?" -eq 0 ]; then
           if [ "$cd" ]; then
-            if [ "$echo" ]; then echo "$cd"; else builtin cd "$cd"; fi
+            if [ "$echo" ]; then echo "$cd"; else builtin $cd_cmd "$cd"; fi
           fi
         else
           return $?
@@ -225,6 +228,7 @@ _z() {
 }
 
 alias ${_Z_CMD:-z}='_z 2>&1'
+alias ${_ZZ_CMD:-zz}='_z -p 2>&1'
 
 [ "$_Z_NO_RESOLVE_SYMLINKS" ] || _Z_RESOLVE_SYMLINKS="-P"
 
@@ -258,6 +262,7 @@ elif type complete >/dev/null 2>&1; then
     # bash
     # tab completion
     complete -o filenames -C '_z --complete "$COMP_LINE"' ${_Z_CMD:-z}
+    complete -o filenames -C '_z --complete "$COMP_LINE"' ${_ZZ_CMD:-zz}
     [ "$_Z_NO_PROMPT_COMMAND" ] || {
         # populate directory list. avoid clobbering other PROMPT_COMMANDs.
         grep "_z --add" <<< "$PROMPT_COMMAND" >/dev/null || {


### PR DESCRIPTION
The original functionality of z command is intact. I have added the following:

 * a command line option "-p" to use pushd instead of cd
 * a new command zz, an alias to "z -p", that uses pushd by default . Similar to z, there is an env. var to change the name of this command
 * Updated man file and README