### PR TITLE
Add verbose flag

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ NAME
        z - jump around
 
 SYNOPSIS
-       z [-chlrtx] [regex1 regex2 ... regexn]
+       z [-chlrtxv] [regex1 regex2 ... regexn]
 
 AVAILABILITY
        bash, zsh
@@ -24,6 +24,8 @@ OPTIONS
        -c     restrict matches to subdirectories of the current directory
 
        -e     echo the best match, don't cd
+
+       -v     cd and echo the new directory
 
        -h     show a brief help message
 

--- a/z.sh
+++ b/z.sh
@@ -21,6 +21,7 @@
 #     * z foo bar # cd to most frecent dir matching foo and bar
 #     * z -r foo  # cd to highest ranked dir matching foo
 #     * z -t foo  # cd to most recently accessed dir matching foo
+#     * z -v foo  # cd to most frecent dir matching foo and echo $PWD
 #     * z -l foo  # list matches instead of cd
 #     * z -e foo  # echo the best match, don't cd
 #     * z -c foo  # restrict matches to subdirs of $PWD
@@ -125,6 +126,7 @@ _z() {
                     c) fnd="^$PWD $fnd";;
                     e) echo=1;;
                     h) echo "${_Z_CMD:-z} [-cehlrtx] args" >&2; return;;
+                    v) verbose=1;;
                     l) list=1;;
                     r) typ="rank";;
                     t) typ="recent";;
@@ -216,7 +218,10 @@ _z() {
 
         if [ "$?" -eq 0 ]; then
           if [ "$cd" ]; then
-            if [ "$echo" ]; then echo "$cd"; else builtin cd "$cd"; fi
+            if [ "$echo" ]; then echo "$cd"
+            else builtin cd "$cd"
+                if [ "$verbose" ]; then echo $PWD; fi
+            fi
           fi
         else
           return $?


### PR DESCRIPTION
Add support for verbose flag (`-v`) that will echo the directory after successful cd. 

Often there are very similar folder names in history.  I noticed that I often typed `$ pwd` to verify I landed in the right place.  With the `-v` you can update the alias like this:

`alias z='_z -v 2>&1'` and get this behavior:

```
(base) tmp $ z -v folder
/private/tmp/another_folder
(base) another_folder $ z -v a_folder
/private/tmp/a_folder
(base) a_folder $ z -v folder
/private/tmp/another_folder
(base) another_folder $
```