### PR TITLE
Run `date` with `command` to bypass aliases.

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -70,7 +70,7 @@ _z() {
         # maintain the data file
         local tempfile="$datafile.$RANDOM"
         local score=${_Z_MAX_SCORE:-9000}
-        _z_dirs | awk -v path="$*" -v now="$(date +%s)" -v score=$score -F"|" '
+        _z_dirs | awk -v path="$*" -v now="$(command date +%s)" -v score=$score -F"|" '
             BEGIN {
                 rank[path] = 1
                 time[path] = now
@@ -144,7 +144,7 @@ _z() {
         [ -f "$datafile" ] || return
 
         local cd
-        cd="$( < <( _z_dirs ) awk -v t="$(date +%s)" -v list="$list" -v typ="$typ" -v q="$fnd" -F"|" '
+        cd="$( < <( _z_dirs ) awk -v t="$(command date +%s)" -v list="$list" -v typ="$typ" -v q="$fnd" -F"|" '
             function frecent(rank, time) {
               # relate frequency and time
               dx = t - time


### PR DESCRIPTION
I have an alias for `date` in my `~/.bash_aliases` file:

```sh
alias date='gdate "+%b %e %Y %l:%M:%S %P"'
```

When I run `z`, I get an error:

```sh
> z deve
gdate: extra operand ‘+%s’
Try 'gdate --help' for more information.
```

That's because `z` uses the aliased `date`, and ends up trying to run `gdate "+%b %e %Y %l:%M:%S %P" +%s` instead of `date +%s`

This PR updates the references to `date` to use `command`, so that it bypasses the alias and executes `/bin/date` directly.