### PR TITLE
Avoid leftover .z.* files.

### DIFF
--- a/z.sh
+++ b/z.sh
@@ -27,6 +27,9 @@
 #     * z -x      # remove the current directory from the datafile
 #     * z -h      # show a brief help message
 
+# Make sure to use the correct env. env is sometimes aliased.
+ENV=/usr/bin/env
+
 [ -d "${_Z_DATA:-$HOME/.z}" ] && {
     echo "ERROR: z.sh's datafile (${_Z_DATA:-$HOME/.z}) is a directory."
 }
@@ -95,10 +98,10 @@ _z() {
         ' 2>/dev/null >| "$tempfile"
         # do our best to avoid clobbering the datafile in a race condition.
         if [ $? -ne 0 -a -f "$datafile" ]; then
-            env rm -f "$tempfile"
+            $ENV rm -f "$tempfile"
         else
             [ "$_Z_OWNER" ] && chown $_Z_OWNER:"$(id -ng $_Z_OWNER)" "$tempfile"
-            env mv -f "$tempfile" "$datafile" || env rm -f "$tempfile"
+            $ENV mv -f "$tempfile" "$datafile" || $ENV rm -f "$tempfile"
         fi
 
     # tab completion


### PR DESCRIPTION
I had recently observed many .z.* files in my home. I tracked this down to the `env` command used by z.sh. I aliased it to `env | sort`. In this case, the temporary files are not removed correctly.
As I'm not the only one with the  problem, I suggest to use `/usr/bin/env` in z.sh.
The problem was also reported on [stackexchange](https://unix.stackexchange.com/questions/700876/why-are-z-files-created-for/744228#744228)